### PR TITLE
On Windows, file dialogs display extension filters followed by a ';'

### DIFF
--- a/file_windows.go
+++ b/file_windows.go
@@ -517,9 +517,11 @@ func initFileTypes(filters FileFilters) (int, *win.COMDLG_FILTERSPEC) {
 			continue
 		}
 		var spec []uint16
-		for _, p := range f.Patterns {
+		for i, p := range f.Patterns {
 			spec = append(spec, syscall.StringToUTF16(p)...)
-			spec[len(spec)-1] = ';'
+			if i != len(f.Patterns)-1 {
+				spec[len(spec)-1] = ';'
+			}
 		}
 		res = append(res, win.COMDLG_FILTERSPEC{
 			Name: syscall.StringToUTF16Ptr(f.Name),

--- a/file_windows.go
+++ b/file_windows.go
@@ -282,7 +282,7 @@ func fileOpenDialog(opts options, multi bool) (string, []string, bool, error) {
 		}
 
 		var lst []string
-		for i := uint32(0); i < count && err == nil; i++ {
+		for i := uint32(0); i < count; i++ {
 			str, err := shellItemPath(items.GetItemAt(i))
 			if err != nil {
 				return "", nil, true, err
@@ -499,7 +499,7 @@ func initFilters(filters FileFilters) *uint16 {
 			res = append(res, syscall.StringToUTF16(p)...)
 			res[len(res)-1] = ';'
 		}
-		res = append(res, 0)
+		res[len(res)-1] = 0
 	}
 	if res != nil {
 		res = append(res, 0)
@@ -517,12 +517,11 @@ func initFileTypes(filters FileFilters) (int, *win.COMDLG_FILTERSPEC) {
 			continue
 		}
 		var spec []uint16
-		for i, p := range f.Patterns {
+		for _, p := range f.Patterns {
 			spec = append(spec, syscall.StringToUTF16(p)...)
-			if i != len(f.Patterns)-1 {
-				spec[len(spec)-1] = ';'
-			}
+			spec[len(spec)-1] = ';'
 		}
+		spec[len(spec)-1] = 0
 		res = append(res, win.COMDLG_FILTERSPEC{
 			Name: syscall.StringToUTF16Ptr(f.Name),
 			Spec: &spec[0],


### PR DESCRIPTION
On Windows, file dialogs display extension filters followed by a ';' even when it's not necessary.

before:
![1](https://github.com/user-attachments/assets/0ffaddfb-cbff-4878-a76b-1c96a3ad23a1)

after:
![2](https://github.com/user-attachments/assets/daf6d47c-fab5-4026-b840-4bd349d7b8b2)


- A simple fix for file dialog handling on Windows regarding extension filters.

